### PR TITLE
fix: modify download templates

### DIFF
--- a/docket/templates/docket/case_transactions.html
+++ b/docket/templates/docket/case_transactions.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <title>Case Transactions</title>
@@ -12,16 +13,32 @@
         }
 
         .header {
-            text-align: center;
-            border-bottom: 2px solid #004080;
-            padding-bottom: 10px;
+            position: relative;
+            height: 70px;
             margin-bottom: 30px;
+            /* border-bottom: 2px solid #004080; */
+        }
+
+        .header img {
+            position: absolute;
+            left: 0;
+            top: 50%;
+            transform: translateY(-50%);
+            height: 50px;
         }
 
         .header h1 {
-            color: #004080;
-            font-size: 24px;
             margin: 0;
+            text-align: center;
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            color: #004080;
+            font-size: 26px;
+            font-weight: 600;
+            letter-spacing: 1px;
+            text-shadow: 1px 1px 1px rgba(0, 64, 128, 0.1);
         }
 
         .case-info {
@@ -76,11 +93,19 @@
         }
     </style>
 </head>
+
 <body>
 
+    <!-- <div class="header">
+        <h1>Transaction Summary</h1>
+    </div> -->
+
     <div class="header">
+        <img src="https://ik.imagekit.io/mazhar/Judgement-Calc/Logo-CIYWy4e5.png?updatedAt=1754417550538"
+            alt="JudgmentCalc Logo">
         <h1>Transaction Summary</h1>
     </div>
+
 
     <div class="case-info">
         <p><strong>Case:</strong> {{ case.case_name }}</p>
@@ -102,18 +127,18 @@
         </thead>
         <tbody>
             {% for txn in transactions %}
-                <tr>
-                    <td>{{ txn.date|date:"m-d,Y" }}</td>
-                    <td>{{ txn.transaction_type }}</td>
-                    <td>${{ txn.amount|floatformat:"2" }}</td>
-                    <td>${{ txn.accrued_interest|floatformat:"2" }}</td>
-                    <td>${{ txn.principal_balance|floatformat:"2" }}</td>
-                    <!-- <td>{{ txn.description }}</td> -->
-                </tr>
+            <tr>
+                <td>{{ txn.date|date:"m-d,Y" }}</td>
+                <td>{{ txn.transaction_type }}</td>
+                <td>${{ txn.amount|floatformat:"2" }}</td>
+                <td>${{ txn.accrued_interest|floatformat:"2" }}</td>
+                <td>${{ txn.principal_balance|floatformat:"2" }}</td>
+                <!-- <td>{{ txn.description }}</td> -->
+            </tr>
             {% empty %}
-                <tr>
-                    <td colspan="6" class="no-data">No transactions available for this case.</td>
-                </tr>
+            <tr>
+                <td colspan="6" class="no-data">No transactions available for this case.</td>
+            </tr>
             {% endfor %}
         </tbody>
     </table>
@@ -123,4 +148,5 @@
     </div>
 
 </body>
+
 </html>

--- a/docket/templates/docket/payoff_statement.html
+++ b/docket/templates/docket/payoff_statement.html
@@ -28,11 +28,24 @@
         .top-info {
             display: flex;
             justify-content: space-between;
-            margin-bottom: 40px;
+            align-items: flex-start;
+            margin-bottom: 30px;
             font-size: 13px;
         }
 
-        .lawyer-info,
+        .lawyer-info {
+            flex: 1;
+            margin-right: 20px;
+        }
+
+        .logo-side img {
+            height: 100px;
+            width: auto;
+            border-radius: 4px;
+            object-fit: contain;
+        }
+
+        /* .lawyer-info, */
         .recipient-info {
             width: 48%;
             line-height: 1.6;
@@ -90,43 +103,57 @@
         <h1>Payoff Statement</h1>
     </div>
 
-    <div class="top-info">
-        <div class="lawyer-info">
-            <p><strong>{{ lawyer.name }}</strong><br>
-                {{ lawyer.firm }}<br>
-                {{ lawyer.address }}<br>
-                {{ lawyer.city_state_zip }}<br>
-                Tel: {{ lawyer.phone }}<br>
-                Email: {{ lawyer.email }}</p>
-        </div>
+    <table width="100%" cellspacing="0" cellpadding="0" style="margin-bottom: 30px;">
+        <tr>
+            <td style="width: 65%; font-size: 13px; vertical-align: top;">
+                <p><strong>{{ lawyer.name }}</strong><br>
+                    {{ lawyer.firm }}<br>
+                    {{ lawyer.address }}<br>
+                    {{ lawyer.city_state_zip }}<br>
+                    Tel: {{ lawyer.phone }}<br>
+                    Email: {{ lawyer.email }}</p>
 
-        {% if debtor_info %}
-        <div class="recipient-info">
-            <p><strong>Debtor Information:</strong><br>
-                {{ debtor_info|linebreaksbr }}<br><br>
-                <strong>Date:</strong> {{ lawyer.date }}
-            </p>
-        </div>
-        {% endif %}
-    </div>
+                {% if debtor_info %}
+                <p><strong>Debtor Information:</strong><br>
+                    {{ debtor_info|linebreaksbr }}<br>
+                    <strong>Phone:</strong> {{ lawyer.debtor_phone }}<br>
+                    <strong>Email:</strong> {{ lawyer.debtor_email }}<br>
+                    <strong>Date:</strong> {{ lawyer.date }}
+                </p>
+                {% endif %}
+            </td>
+            <td style="width: 35%; text-align: right; vertical-align: top;">
+                <img src="{{ lawyer.image }}" alt="Lawyer Logo"
+                    style="width: 120px; height: auto; border-radius: 4px;" />
+            </td>
+        </tr>
+    </table>
 
     <div class="section-title">Case Details</div>
 
     <div class="case-info">
         <p><strong>{{ case.case_name }}</strong></p>
         <p>{{ case.court_name }} - Case No. {{ case.court_case_number }}</p>
-        <p><strong>Judgment Amount:</strong> ${{ case.judgment_amount|floatformat:"2" }} (entered {{ case.judgment_date }})</p>
+        <p><strong>Judgment Amount:</strong> ${{ case.judgment_amount|floatformat:"2" }} (entered {{ case.judgment_date
+            }})</p>
     </div>
 
     <div class="section-title">Total Payoff</div>
 
-    <div class="payoff-box">
-        ${{ payoff_amount|floatformat:"2" }} <br />
-        <span style="font-size: 12px; font-weight: normal;">As of {{ today }}</span>
-    </div>
+    <table align="center" cellspacing="0" cellpadding="0" border="0">
+        <tr>
+            <td width="200"
+                style="border: 2px solid #004080; background-color: #f1f7ff; padding: 5px 0px 0px opx ; font-size: 16px; font-weight: bold; color: #004080; text-align: center;">
+                ${{ payoff_amount|floatformat:"2" }}<br />
+                <span style="font-size: 12px; font-weight: normal;">As of {{ today }}</span>
+            </td>
+        </tr>
+    </table>
+
 
     <div class="info-text">
-        Interest accrues at a daily rate of <strong>${{ daily_interest|floatformat:"2" }}</strong> per day after <strong>{{ interest_start_date }}</strong>.
+        Interest accrues at a daily rate of <strong>${{ daily_interest|floatformat:"2" }}</strong> per day after
+        <strong>{{ interest_start_date }}</strong>.
     </div>
 
     <div class="footer">

--- a/docket/views.py
+++ b/docket/views.py
@@ -895,6 +895,7 @@ class GeneratePayoffPDFView(APIView):
             'city_state_zip': f"{user.state or ''}, {user.country or ''} {user.postal_code or ''}".strip(', '),
             'phone': user.phone_number or "N/A",
             'email': user.email,
+            'image': user.image,
             'date': now().strftime('%B %d, %Y')
         }
 


### PR DESCRIPTION
Resolved an issue where the payoff box appeared too wide in the generated PDF due to xhtml2pdf's limited CSS support.

Changes made:
- Replaced the previous <div>-based box with a table layout using <table> and <td> elements.
- Applied fixed width via the <td width="220"> attribute to ensure consistent box sizing.
- Used align="center" for compatibility with xhtml2pdf rendering engine.
- Removed unsupported CSS styles such as display: inline-block and margin auto which xhtml2pdf ignores.

Tested and verified that the payoff box is now centered and rendered at the correct width in the final PDF.
